### PR TITLE
ci: fix urls

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
           version: 'latest'
       - name: Trunk build
         working-directory: fancy-example
-        run: trunk build --release --public-url hello_egui
+        run: trunk build --release --public-url /hello_egui
       - name: Deploy pages
         uses: crazy-max/ghaction-github-pages@v2
         with:


### PR DESCRIPTION
I saw you examples are not running,

I had the same problem:
![image](https://github.com/lucasmerlin/hello_egui/assets/88315530/5079332a-e769-454b-9be8-65c134c637f3)
![image](https://github.com/lucasmerlin/hello_egui/assets/88315530/3f1d9a0d-b423-4acf-8ef1-55da6ce51909)

it seems trunk had a breaking change.

Adding the slash worked for me: https://github.com/SilenLoc/TypeFast/blame/97c9a219692b7479e6790f906c654b5c622ffead/.github/workflows/release.yml#L31