### PR TITLE
Make `add_container` public again

### DIFF
--- a/crates/egui_flex/src/lib.rs
+++ b/crates/egui_flex/src/lib.rs
@@ -904,7 +904,7 @@ impl FlexInstance<'_> {
     }
 
     #[allow(clippy::too_many_lines)] // TODO: Refactor this to be more readable
-    fn add_container<R>(&mut self, mut item: FlexItem, content: ContentFn<R>) -> InnerResponse<R> {
+    pub fn add_container<R>(&mut self, mut item: FlexItem, content: ContentFn<R>) -> InnerResponse<R> {
         let row = self.rows.get_mut(self.current_row);
 
         if let Some(row) = &row {


### PR DESCRIPTION
I was using `add_container` as follows:
```rust
let continue_response =
    flex.add_container(egui_flex::item().grow(1.0), Box::new(|ui, container| {
        ui.add_enabled_ui(is_enabled, |ui| {
            container.content_widget(ui, egui::Button::new("[C] Restart"))
        })
        .inner
    }));
```
as a work-around for item growth not applying recursively to inner UI elements.

If I try to use the following code:
```rust
let continue_response = flex.add_ui(egui_flex::item().grow(1.0), |ui| {
    let is_enabled = time.elapsed() - *last_requested_respawn_at
        > Duration::from_secs_f32(RESPAWN_REQUEST_COOLDOWN_SECS);
    ui.add_enabled(is_enabled, egui::Button::new("[C] Restart"))
});
```

my UI looks like this (note the Restart button not occupying all the available width):
![ui](https://github.com/user-attachments/assets/0640fe1c-403e-4189-ba61-1593642de618)

Probably there's a better solution for this particular problem, I'd appreciate it as well, but at this point maybe we could just make `add_container` public again.