### PR TITLE
Make `dnd` Vec functions work on any `DragDropItem`

### DIFF
--- a/crates/egui_dnd/src/lib.rs
+++ b/crates/egui_dnd/src/lib.rs
@@ -175,23 +175,29 @@ impl<'a> Dnd<'a> {
     }
 
     /// Same as [`Dnd::show`], but automatically sorts the items.
-    pub fn show_vec<T: Hash>(
+    pub fn show_vec<T>(
         self,
         items: &mut [T],
         item_ui: impl FnMut(&mut Ui, &mut T, Handle, ItemState),
-    ) -> DragDropResponse {
+    ) -> DragDropResponse
+    where
+        for<'b> &'b mut T: DragDropItem,
+    {
         let response = self.show(items.iter_mut(), item_ui);
         response.update_vec(items);
         response
     }
 
     /// Same as [`Dnd::show_sized`], but automatically sorts the items.
-    pub fn show_vec_sized<T: Hash>(
+    pub fn show_vec_sized<T: DragDropItem>(
         self,
         items: &mut [T],
         size: egui::Vec2,
         item_ui: impl FnMut(&mut Ui, &mut T, Handle, ItemState),
-    ) -> DragDropResponse {
+    ) -> DragDropResponse
+    where
+        for<'b> &'b mut T: DragDropItem,
+    {
         let response = self.show_sized(items.iter_mut(), size, item_ui);
         response.update_vec(items);
         response
@@ -205,7 +211,7 @@ impl<'a> Dnd<'a> {
     }
 
     /// Same as [`Dnd::show_custom`], but automatically sorts the items.
-    pub fn show_custom_vec<T: Hash>(
+    pub fn show_custom_vec<T: DragDropItem>(
         self,
         items: &mut [T],
         f: impl FnOnce(&mut Ui, &mut [T], &mut ItemIterator),

--- a/crates/egui_dnd/src/state.rs
+++ b/crates/egui_dnd/src/state.rs
@@ -1,4 +1,3 @@
-use std::hash::Hash;
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::{Duration, SystemTime};
 
@@ -16,7 +15,7 @@ pub trait DragDropItem {
     fn id(&self) -> Id;
 }
 
-impl<T: Hash> DragDropItem for T {
+impl<T: std::hash::Hash> DragDropItem for T {
     fn id(&self) -> Id {
         Id::new(self)
     }


### PR DESCRIPTION
Right now, `dnd` functions that operate on `Vec`s require the item type to be `Hash`.  This PR loosens that restriction, allowing any inner type which implements `DragDropItem` (which was already the case for the lower-level `Dnd::show`).

For types with a bunch of internal state, this lets us generate the id without hashing the entire object!

Because of the blanket `impl<T: std::hash::Hash> DragDropItem for T`, the change is backwards-compatible.