### PR TITLE
feat(egui_material_icons): remove compressed from default features

### DIFF
--- a/crates/egui_material_icons/Cargo.toml
+++ b/crates/egui_material_icons/Cargo.toml
@@ -11,12 +11,15 @@ repository = "https://github.com/lucasmerlin/hello_egui/tree/main/crates/egui_ma
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["filled", "compressed"]
+default = ["filled"]
 ## Include the filled font variant.
 filled = []
 ## Include the outline font variant.
 outline = []
-## Compress embedded fonts with DEFLATE. Reduces binary size significantly.
+## Compress embedded fonts with DEFLATE at compile time, decompressing at runtime.
+## This reduces the binary size for native targets but is counterproductive for wasm,
+## where transport compression (gzip/brotli) is more effective and the decompression
+## runtime (zstd + libflate) adds significant overhead.
 compressed = ["dep:include-flate"]
 
 [dependencies]

--- a/crates/egui_material_icons/README.md
+++ b/crates/egui_material_icons/README.md
@@ -27,12 +27,12 @@ Currently, this provides the rounded icons. By default, the filled variant is us
 
 ## Features
 
-| Features                                            | Fonts Included     |
-| --------------------------------------------------- | ------------------ |
-| default (`filled`, `compressed`)                    | Filled only        |
-| `--features outline`                                | Filled + Outline   |
-| `--no-default-features --features outline`          | Outline only       |
-| `--no-default-features --features "filled outline"` | Both, uncompressed |
+| Features                                            | Fonts Included   |
+| --------------------------------------------------- | ---------------- |
+| default (`filled`)                                  | Filled only      |
+| `--features outline`                                | Filled + Outline |
+| `--no-default-features --features outline`          | Outline only     |
+| `--no-default-features --features "filled outline"` | Both             |
 
 - **`filled`** (default) - Include the filled font variant.
 
@@ -44,11 +44,14 @@ Currently, this provides the rounded icons. By default, the filled variant is us
   fn init(ctx: &egui::Context) {
     egui_material_icons::initialize(ctx);
   }
-  
+
   fn my_ui(ui: &mut egui::Ui) {
     ui.button(ICON_ADD);          // filled
     ui.button(ICON_ADD.outlined());  // outlined
   }
   ```
 
-- **`compressed`** (default) - Compress embedded fonts with DEFLATE, reducing binary size significantly.
+- **`compressed`** - Compress embedded fonts with DEFLATE at compile time, decompressing at runtime.
+  This can reduce binary size for native targets, but is **not recommended for wasm**: transport
+  compression (gzip/brotli) is more effective and the decompression runtime (zstd + libflate) adds
+  ~250 KB of code to the wasm binary, resulting in a larger final download.

--- a/crates/egui_material_icons/src/lib.rs
+++ b/crates/egui_material_icons/src/lib.rs
@@ -19,11 +19,7 @@ pub mod icons;
 #[cfg(all(feature = "filled", not(feature = "compressed")))]
 pub(crate) const FONT_DATA: &[u8] = include_bytes!("../MaterialSymbolsRounded_Filled-Regular.ttf");
 
-#[cfg(all(
-    feature = "outline",
-    not(feature = "filled"),
-    not(feature = "compressed")
-))]
+#[cfg(all(feature = "outline", not(feature = "filled"), not(feature = "compressed")))]
 pub(crate) const FONT_DATA: &[u8] = include_bytes!("../MaterialSymbolsRounded-Regular.ttf");
 
 #[cfg(all(feature = "filled", feature = "outline", not(feature = "compressed")))]

--- a/crates/egui_material_icons/src/lib.rs
+++ b/crates/egui_material_icons/src/lib.rs
@@ -19,7 +19,11 @@ pub mod icons;
 #[cfg(all(feature = "filled", not(feature = "compressed")))]
 pub(crate) const FONT_DATA: &[u8] = include_bytes!("../MaterialSymbolsRounded_Filled-Regular.ttf");
 
-#[cfg(all(feature = "outline", not(feature = "filled"), not(feature = "compressed")))]
+#[cfg(all(
+    feature = "outline",
+    not(feature = "filled"),
+    not(feature = "compressed")
+))]
 pub(crate) const FONT_DATA: &[u8] = include_bytes!("../MaterialSymbolsRounded-Regular.ttf");
 
 #[cfg(all(feature = "filled", feature = "outline", not(feature = "compressed")))]


### PR DESCRIPTION
## Summary
- Remove `compressed` from the default feature set for `egui_material_icons`
- Keep the `compressed` feature available for native targets that benefit from it
- Add documentation warning against using `compressed` for wasm targets

## Motivation

Benchmarking showed that the `compressed` feature (include-flate with zstd+libflate) is counterproductive for wasm:

| | With `compressed` | Without (plain `include_bytes`) |
|---|---|---|
| **Raw .wasm** | 874 KB | 1,550 KB |
| **Gzipped .wasm** | 690 KB | 525 KB |

The zstd decompression runtime adds ~250 KB of code to the wasm binary, and the pre-compressed font data doesn't benefit from transport compression (gzip/brotli). The net result is a **24% larger** gzipped download with the feature enabled.