### PR TITLE
Add axis constraining to egui_dnd

### DIFF
--- a/crates/egui_dnd/CHANGELOG.md
+++ b/crates/egui_dnd/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add `Dnd::with_drag_axis` / `DragDropUi::with_drag_axis` and the `DragAxis` enum to constrain drag motion to the horizontal or vertical axis only
+
 ## 0.16.0
 
 - Update egui to 0.35

--- a/crates/egui_dnd/examples/constrain_axis.rs
+++ b/crates/egui_dnd/examples/constrain_axis.rs
@@ -1,0 +1,31 @@
+use eframe::{egui, NativeOptions};
+use egui::CentralPanel;
+use egui_dnd::{dnd, DragAxis};
+
+pub fn main() -> eframe::Result<()> {
+    let mut items = vec!["alfred", "bernhard", "christian", "dominik"];
+
+    eframe::run_ui_native(
+        "DnD Constrain Axis Example",
+        NativeOptions::default(),
+        move |ui, _frame| {
+            CentralPanel::default().show(ui, |ui| {
+                ui.label("The dragged item can only move vertically:");
+                dnd(ui, "dnd_example")
+                    .with_drag_axis(DragAxis::Vertical)
+                    .show_vec(&mut items, |ui, item, handle, state| {
+                        ui.horizontal(|ui| {
+                            handle.ui(ui, |ui| {
+                                if state.dragged {
+                                    ui.label("dragging");
+                                } else {
+                                    ui.label("drag");
+                                }
+                            });
+                            ui.label(*item);
+                        });
+                    });
+            });
+        },
+    )
+}

--- a/crates/egui_dnd/src/item.rs
+++ b/crates/egui_dnd/src/item.rs
@@ -66,9 +66,11 @@ impl<'a> Item<'a> {
         let unique_id = Self::unique_id(id, self.ui_id);
         let index = self.state.index;
         let last_pointer_pos = self.dnd_state.detection_state.last_pointer_pos();
+        let drag_axis = self.dnd_state.drag_axis;
         if let DragDetectionState::Dragging {
             id: dragging_id,
             offset,
+            drag_start_pos,
             ..
         } = &mut self.dnd_state.detection_state
         {
@@ -81,7 +83,7 @@ impl<'a> Item<'a> {
                     .pointer_hover_pos()
                     .or(last_pointer_pos)
                     .unwrap_or_else(|| ui.next_widget_position());
-                let position = pointer_pos + *offset;
+                let position = drag_axis.constrain(*drag_start_pos, pointer_pos + *offset);
 
                 // We animate so the animated position is updated, even though we don't use it here.
                 animate_position(

--- a/crates/egui_dnd/src/lib.rs
+++ b/crates/egui_dnd/src/lib.rs
@@ -3,7 +3,7 @@
 #![warn(missing_docs)]
 
 use egui::{AsId, Id, Ui};
-pub use state::{DragDropConfig, DragDropItem, DragDropResponse, DragUpdate, Handle};
+pub use state::{DragAxis, DragDropConfig, DragDropItem, DragDropResponse, DragUpdate, Handle};
 
 pub use crate::item_iterator::ItemIterator;
 use crate::state::DragDropUi;
@@ -85,6 +85,15 @@ impl<'a> Dnd<'a> {
     #[must_use]
     pub fn with_touch_config(mut self, config: Option<DragDropConfig>) -> Self {
         self.drag_drop_ui = self.drag_drop_ui.with_touch_config(config);
+        self
+    }
+
+    /// Constrains the motion of the dragged item to a single axis.
+    /// This only affects the visual position of the floating item.
+    /// The default is [`DragAxis::Both`] (no constraint).
+    #[must_use]
+    pub fn with_drag_axis(mut self, axis: DragAxis) -> Self {
+        self.drag_drop_ui = self.drag_drop_ui.with_drag_axis(axis);
         self
     }
 

--- a/crates/egui_dnd/src/state.rs
+++ b/crates/egui_dnd/src/state.rs
@@ -9,6 +9,29 @@ use web_time::{Duration, SystemTime};
 use crate::item_iterator::ItemIterator;
 use crate::utils::shift_vec;
 
+/// Dragged item motion constraint
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DragAxis {
+    /// The item follows the pointer freely in both directions (default).
+    #[default]
+    Both,
+    /// The item only follows the pointer horizontally. Its vertical position stays fixed.
+    Horizontal,
+    /// The item only follows the pointer vertically. Its horizontal position stays fixed.
+    Vertical,
+}
+
+impl DragAxis {
+    /// Constrain `pos` relative to the position the drag started at (`start`).
+    pub(crate) fn constrain(self, start: Pos2, pos: Pos2) -> Pos2 {
+        match self {
+            DragAxis::Both => pos,
+            DragAxis::Horizontal => Pos2::new(pos.x, start.y),
+            DragAxis::Vertical => Pos2::new(start.x, pos.y),
+        }
+    }
+}
+
 /// Item that can be reordered using drag and drop
 pub trait DragDropItem {
     /// Unique id for the item, to allow egui to keep track of its dragged state between frames
@@ -110,6 +133,7 @@ pub struct DragDropUi {
     mouse_config: DragDropConfig,
     pub(crate) swap_animation_time: f32,
     pub(crate) return_animation_time: f32,
+    pub(crate) drag_axis: DragAxis,
 }
 
 impl Default for DragDropUi {
@@ -120,6 +144,7 @@ impl Default for DragDropUi {
             mouse_config: DragDropConfig::mouse(),
             swap_animation_time: 0.2,
             return_animation_time: 0.2,
+            drag_axis: DragAxis::Both,
         }
     }
 }
@@ -155,6 +180,7 @@ pub(crate) enum DragDetectionState {
         id: Id,
         source_idx: usize,
         offset: Vec2,
+        drag_start_pos: Pos2,
         dragged_item_size: Vec2,
         closest_item: (Id, Pos2),
         last_pointer_pos: Pos2,
@@ -365,6 +391,8 @@ impl<'a> Handle<'a> {
             self.state.detection_state = DragDetectionState::Dragging {
                 id: self.id,
                 offset,
+                // At the start of the drag the floating item sits at its original position.
+                drag_start_pos: self.item_pos,
                 // We set this in the Item
                 dragged_item_size: Vec2::default(),
                 closest_item: (self.id, self.item_pos),
@@ -460,6 +488,13 @@ impl DragDropUi {
         self
     }
 
+    /// Constrains the motion of the dragged item to a single axis.
+    /// The default is [`DragAxis::Both`] (no constraint).
+    pub fn with_drag_axis(mut self, axis: DragAxis) -> Self {
+        self.drag_axis = axis;
+        self
+    }
+
     fn config(&self, ui: &Ui) -> &DragDropConfig {
         if ui.input(egui::InputState::any_touches) {
             self.touch_config.as_ref().unwrap_or(&self.mouse_config)
@@ -534,13 +569,14 @@ impl DragDropUi {
         let dragged_item_rect = if let DragDetectionState::Dragging {
             offset,
             dragged_item_size,
+            drag_start_pos,
             ..
         } = &self.detection_state
         {
-            Some(Rect::from_min_size(
-                pointer_pos.unwrap_or_default() + *offset,
-                *dragged_item_size,
-            ))
+            let position = self
+                .drag_axis
+                .constrain(*drag_start_pos, pointer_pos.unwrap_or_default() + *offset);
+            Some(Rect::from_min_size(position, *dragged_item_size))
         } else {
             None
         };


### PR DESCRIPTION
I have an app where the egui window is quite thin horizontally on purpose, so it was too easy to drag-and-drop items outside the frame.

This adds axis constraints so the floating item can't be moved visually out of bounds in that case.