### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.12.1
+
+- Fix release-plz config for unpublished crates, update release PR description
+- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
+- Fix CI
+- Update egui to 0.36 and MSRV to 1.95 ([#104](https://github.com/lucasmerlin/hello_egui/pull/104))
+
 ## 0.12.0
 
 - Update egui to 0.35

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.12.1
+## 0.13.0
 
 - Fix release-plz config for unpublished crates, update release PR description
 - Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "egui_animation"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "eframe",
  "egui",
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "egui_dnd"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "color-hex",
  "eframe",
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "egui_flex"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "eframe",
  "egui",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "egui_form"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "eframe",
  "egui",
@@ -1720,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "egui_inbox"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "derive-new",
  "eframe",
@@ -1738,7 +1738,7 @@ dependencies = [
 
 [[package]]
 name = "egui_infinite_scroll"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "eframe",
  "egui",
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "egui_material_icons"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "eframe",
  "egui",
@@ -1782,7 +1782,7 @@ dependencies = [
 
 [[package]]
 name = "egui_pull_to_refresh"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "eframe",
  "egui",
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "egui_router"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "eframe",
  "egui",
@@ -1810,7 +1810,7 @@ dependencies = [
 
 [[package]]
 name = "egui_suspense"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "eframe",
  "egui",
@@ -1824,7 +1824,7 @@ dependencies = [
 
 [[package]]
 name = "egui_thumbhash"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "ahash",
  "base64",
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "egui_virtual_list"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "eframe",
  "egui",
@@ -2917,7 +2917,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello_egui"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "egui_animation",
  "egui_dnd",
@@ -2935,7 +2935,7 @@ dependencies = [
 
 [[package]]
 name = "hello_egui_utils"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "concat-idents",
  "egui",
@@ -2945,7 +2945,7 @@ dependencies = [
 
 [[package]]
 name = "hello_egui_utils_dev"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "eframe",
  "egui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "egui_animation"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "eframe",
  "egui",
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "egui_dnd"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "color-hex",
  "eframe",
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "egui_flex"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "eframe",
  "egui",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "egui_form"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "eframe",
  "egui",
@@ -1720,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "egui_inbox"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "derive-new",
  "eframe",
@@ -1738,7 +1738,7 @@ dependencies = [
 
 [[package]]
 name = "egui_infinite_scroll"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "eframe",
  "egui",
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "egui_material_icons"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "eframe",
  "egui",
@@ -1782,7 +1782,7 @@ dependencies = [
 
 [[package]]
 name = "egui_pull_to_refresh"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "eframe",
  "egui",
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "egui_router"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "eframe",
  "egui",
@@ -1810,7 +1810,7 @@ dependencies = [
 
 [[package]]
 name = "egui_suspense"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "eframe",
  "egui",
@@ -1824,7 +1824,7 @@ dependencies = [
 
 [[package]]
 name = "egui_thumbhash"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "ahash",
  "base64",
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "egui_virtual_list"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "eframe",
  "egui",
@@ -2917,7 +2917,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello_egui"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "egui_animation",
  "egui_dnd",
@@ -2935,7 +2935,7 @@ dependencies = [
 
 [[package]]
 name = "hello_egui_utils"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "concat-idents",
  "egui",
@@ -2945,7 +2945,7 @@ dependencies = [
 
 [[package]]
 name = "hello_egui_utils_dev"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "eframe",
  "egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello_egui"
-version = "0.12.1"
+version = "0.13.0"
 edition = "2021"
 description = "A collection of useful crates for egui."
 authors = ["Lucas Meurer"]
@@ -68,21 +68,21 @@ exclude = ["crates/egui_taffy"]
 resolver = "2"
 
 [workspace.dependencies]
-egui_dnd = { path = "./crates/egui_dnd", version = "0.16.1" }
-egui_animation = { path = "./crates/egui_animation", version = "0.12.1" }
-hello_egui_utils = { path = "./crates/hello_egui_utils", version = "0.12.1" }
-hello_egui_utils_dev = { path = "./crates/hello_egui_utils_dev", version = "0.4.1" }
-egui_flex = { path = "./crates/egui_flex", version = "0.7.1" }
-egui_form = { path = "./crates/egui_form", version = "0.9.1" }
-egui_inbox = { path = "./crates/egui_inbox", version = "0.12.1" }
-egui_pull_to_refresh = { path = "./crates/egui_pull_to_refresh", version = "0.12.1" }
-egui_router = { path = "./crates/egui_router", version = "0.8.1" }
-egui_suspense = { path = "./crates/egui_suspense", version = "0.12.1" }
-egui_virtual_list = { path = "./crates/egui_virtual_list", version = "0.11.1" }
-egui_infinite_scroll = { path = "./crates/egui_infinite_scroll", version = "0.11.1" }
-egui_thumbhash = { path = "./crates/egui_thumbhash", version = "0.11.1" }
-egui_material_icons = { path = "./crates/egui_material_icons", version = "0.7.1" }
-hello_egui = { path = ".", version = "0.12.1" }
+egui_dnd = { path = "./crates/egui_dnd", version = "0.17.0" }
+egui_animation = { path = "./crates/egui_animation", version = "0.13.0" }
+hello_egui_utils = { path = "./crates/hello_egui_utils", version = "0.13.0" }
+hello_egui_utils_dev = { path = "./crates/hello_egui_utils_dev", version = "0.5.0" }
+egui_flex = { path = "./crates/egui_flex", version = "0.8.0" }
+egui_form = { path = "./crates/egui_form", version = "0.10.0" }
+egui_inbox = { path = "./crates/egui_inbox", version = "0.13.0" }
+egui_pull_to_refresh = { path = "./crates/egui_pull_to_refresh", version = "0.13.0" }
+egui_router = { path = "./crates/egui_router", version = "0.9.0" }
+egui_suspense = { path = "./crates/egui_suspense", version = "0.13.0" }
+egui_virtual_list = { path = "./crates/egui_virtual_list", version = "0.12.0" }
+egui_infinite_scroll = { path = "./crates/egui_infinite_scroll", version = "0.12.0" }
+egui_thumbhash = { path = "./crates/egui_thumbhash", version = "0.12.0" }
+egui_material_icons = { path = "./crates/egui_material_icons", version = "0.8.0" }
+hello_egui = { path = ".", version = "0.13.0" }
 
 egui = { version = "0.36.0", default-features = false }
 egui_kittest = { version = "0.36.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello_egui"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 description = "A collection of useful crates for egui."
 authors = ["Lucas Meurer"]
@@ -68,21 +68,21 @@ exclude = ["crates/egui_taffy"]
 resolver = "2"
 
 [workspace.dependencies]
-egui_dnd = { path = "./crates/egui_dnd", version = "0.16.0" }
-egui_animation = { path = "./crates/egui_animation", version = "0.12.0" }
-hello_egui_utils = { path = "./crates/hello_egui_utils", version = "0.12.0" }
-hello_egui_utils_dev = { path = "./crates/hello_egui_utils_dev", version = "0.4.0" }
-egui_flex = { path = "./crates/egui_flex", version = "0.7.0" }
-egui_form = { path = "./crates/egui_form", version = "0.9.0" }
-egui_inbox = { path = "./crates/egui_inbox", version = "0.12.0" }
-egui_pull_to_refresh = { path = "./crates/egui_pull_to_refresh", version = "0.12.0" }
-egui_router = { path = "./crates/egui_router", version = "0.8.0" }
-egui_suspense = { path = "./crates/egui_suspense", version = "0.12.0" }
-egui_virtual_list = { path = "./crates/egui_virtual_list", version = "0.11.0" }
-egui_infinite_scroll = { path = "./crates/egui_infinite_scroll", version = "0.11.0" }
-egui_thumbhash = { path = "./crates/egui_thumbhash", version = "0.11.0" }
-egui_material_icons = { path = "./crates/egui_material_icons", version = "0.7.0" }
-hello_egui = { path = ".", version = "0.12.0" }
+egui_dnd = { path = "./crates/egui_dnd", version = "0.16.1" }
+egui_animation = { path = "./crates/egui_animation", version = "0.12.1" }
+hello_egui_utils = { path = "./crates/hello_egui_utils", version = "0.12.1" }
+hello_egui_utils_dev = { path = "./crates/hello_egui_utils_dev", version = "0.4.1" }
+egui_flex = { path = "./crates/egui_flex", version = "0.7.1" }
+egui_form = { path = "./crates/egui_form", version = "0.9.1" }
+egui_inbox = { path = "./crates/egui_inbox", version = "0.12.1" }
+egui_pull_to_refresh = { path = "./crates/egui_pull_to_refresh", version = "0.12.1" }
+egui_router = { path = "./crates/egui_router", version = "0.8.1" }
+egui_suspense = { path = "./crates/egui_suspense", version = "0.12.1" }
+egui_virtual_list = { path = "./crates/egui_virtual_list", version = "0.11.1" }
+egui_infinite_scroll = { path = "./crates/egui_infinite_scroll", version = "0.11.1" }
+egui_thumbhash = { path = "./crates/egui_thumbhash", version = "0.11.1" }
+egui_material_icons = { path = "./crates/egui_material_icons", version = "0.7.1" }
+hello_egui = { path = ".", version = "0.12.1" }
 
 egui = { version = "0.36.0", default-features = false }
 egui_kittest = { version = "0.36.0" }

--- a/crates/egui_animation/CHANGELOG.md
+++ b/crates/egui_animation/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.1
+
+- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
+
 ## 0.12.0
 
 - Update egui to 0.35

--- a/crates/egui_animation/CHANGELOG.md
+++ b/crates/egui_animation/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 0.12.1
+## 0.13.0
 
+- Update egui to 0.36
 - Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
 
 ## 0.12.0

--- a/crates/egui_animation/Cargo.toml
+++ b/crates/egui_animation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_animation"
-version = "0.12.1"
+version = "0.13.0"
 edition = "2021"
 description = "Experimental animation utilities for egui, including easing functions and a collapse view."
 license = "MIT"

--- a/crates/egui_animation/Cargo.toml
+++ b/crates/egui_animation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_animation"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 description = "Experimental animation utilities for egui, including easing functions and a collapse view."
 license = "MIT"

--- a/crates/egui_dnd/CHANGELOG.md
+++ b/crates/egui_dnd/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 0.16.1
+## 0.17.0
 
+- Update egui to 0.36
 - Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
 - Add axis constraining to egui_dnd ([#103](https://github.com/lucasmerlin/hello_egui/pull/103))
 

--- a/crates/egui_dnd/CHANGELOG.md
+++ b/crates/egui_dnd/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.16.1
+
+- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
+- Add axis constraining to egui_dnd ([#103](https://github.com/lucasmerlin/hello_egui/pull/103))
+
 ## 0.16.0
 
 - Update egui to 0.35

--- a/crates/egui_dnd/Cargo.toml
+++ b/crates/egui_dnd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_dnd"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2021"
 authors = ["Lucas Meurer"]
 repository = "https://github.com/lucasmerlin/hello_egui/tree/main/crates/egui_dnd"

--- a/crates/egui_dnd/Cargo.toml
+++ b/crates/egui_dnd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_dnd"
-version = "0.16.1"
+version = "0.17.0"
 edition = "2021"
 authors = ["Lucas Meurer"]
 repository = "https://github.com/lucasmerlin/hello_egui/tree/main/crates/egui_dnd"

--- a/crates/egui_flex/CHANGELOG.md
+++ b/crates/egui_flex/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.1
+
+- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
+
 ## 0.7.0
 
 - Update egui to 0.35

--- a/crates/egui_flex/CHANGELOG.md
+++ b/crates/egui_flex/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 0.7.1
+## 0.8.0
 
+- Update egui to 0.36
 - Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
 
 ## 0.7.0

--- a/crates/egui_flex/Cargo.toml
+++ b/crates/egui_flex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_flex"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 repository = "https://github.com/lucasmerlin/hello_egui/tree/main/crates/egui_flex"
 homepage = "https://lucasmerlin.github.io/hello_egui/#/example/flex"

--- a/crates/egui_flex/Cargo.toml
+++ b/crates/egui_flex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_flex"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 repository = "https://github.com/lucasmerlin/hello_egui/tree/main/crates/egui_flex"
 homepage = "https://lucasmerlin.github.io/hello_egui/#/example/flex"

--- a/crates/egui_form/CHANGELOG.md
+++ b/crates/egui_form/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.1
+
+- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
+
 ## 0.9.0
 
 - Update egui to 0.35

--- a/crates/egui_form/CHANGELOG.md
+++ b/crates/egui_form/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 0.9.1
+## 0.10.0
 
+- Update egui to 0.36
 - Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
 
 ## 0.9.0

--- a/crates/egui_form/Cargo.toml
+++ b/crates/egui_form/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_form"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 description = "Form validation for egui"
 license = "MIT"

--- a/crates/egui_form/Cargo.toml
+++ b/crates/egui_form/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_form"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 description = "Form validation for egui"
 license = "MIT"

--- a/crates/egui_inbox/CHANGELOG.md
+++ b/crates/egui_inbox/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.1
+
+- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
+
 ## 0.12.0
 
 - Update egui to 0.35

--- a/crates/egui_inbox/CHANGELOG.md
+++ b/crates/egui_inbox/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 0.12.1
+## 0.13.0
 
+- Update egui to 0.36
 - Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
 
 ## 0.12.0

--- a/crates/egui_inbox/Cargo.toml
+++ b/crates/egui_inbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_inbox"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 description = "Utility to send messages to egui views from async functions, callbacks, etc. without having to use interior mutability."
 license = "MIT"

--- a/crates/egui_inbox/Cargo.toml
+++ b/crates/egui_inbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_inbox"
-version = "0.12.1"
+version = "0.13.0"
 edition = "2021"
 description = "Utility to send messages to egui views from async functions, callbacks, etc. without having to use interior mutability."
 license = "MIT"

--- a/crates/egui_infinite_scroll/CHANGELOG.md
+++ b/crates/egui_infinite_scroll/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 0.11.1
+## 0.12.0
 
+- Update egui to 0.36
 - Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
 
 ## 0.11.0

--- a/crates/egui_infinite_scroll/CHANGELOG.md
+++ b/crates/egui_infinite_scroll/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.11.1
+
+- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
+
 ## 0.11.0
 
 - Update egui to 0.35

--- a/crates/egui_infinite_scroll/Cargo.toml
+++ b/crates/egui_infinite_scroll/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_infinite_scroll"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 authors = ["Lucas Meurer"]
 homepage = "https://lucasmerlin.github.io/hello_egui/"

--- a/crates/egui_infinite_scroll/Cargo.toml
+++ b/crates/egui_infinite_scroll/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_infinite_scroll"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2021"
 authors = ["Lucas Meurer"]
 homepage = "https://lucasmerlin.github.io/hello_egui/"

--- a/crates/egui_material_icons/CHANGELOG.md
+++ b/crates/egui_material_icons/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.1
+
+- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
+
 ## 0.7.0
 
 - Update egui to 0.35

--- a/crates/egui_material_icons/CHANGELOG.md
+++ b/crates/egui_material_icons/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 0.7.1
+## 0.8.0
 
+- Update egui to 0.36
 - Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
 
 ## 0.7.0

--- a/crates/egui_material_icons/Cargo.toml
+++ b/crates/egui_material_icons/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_material_icons"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 categories = ["gui"]
 keywords = ["egui", "icons", "material"]

--- a/crates/egui_material_icons/Cargo.toml
+++ b/crates/egui_material_icons/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_material_icons"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 categories = ["gui"]
 keywords = ["egui", "icons", "material"]

--- a/crates/egui_pull_to_refresh/CHANGELOG.md
+++ b/crates/egui_pull_to_refresh/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.1
+
+- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
+
 ## 0.12.0
 
 - Update egui to 0.35

--- a/crates/egui_pull_to_refresh/CHANGELOG.md
+++ b/crates/egui_pull_to_refresh/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 0.12.1
+## 0.13.0
 
+- Update egui to 0.36
 - Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
 
 ## 0.12.0

--- a/crates/egui_pull_to_refresh/Cargo.toml
+++ b/crates/egui_pull_to_refresh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_pull_to_refresh"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 description = "A pull to refresh library for egui"
 license = "MIT"

--- a/crates/egui_pull_to_refresh/Cargo.toml
+++ b/crates/egui_pull_to_refresh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_pull_to_refresh"
-version = "0.12.1"
+version = "0.13.0"
 edition = "2021"
 description = "A pull to refresh library for egui"
 license = "MIT"

--- a/crates/egui_router/CHANGELOG.md
+++ b/crates/egui_router/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.1
+
+- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
+
 ## 0.8.0
 
 - Add `EguiRouter::replace_url` for in-place URL updates that preserve the history state index

--- a/crates/egui_router/CHANGELOG.md
+++ b/crates/egui_router/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 0.8.1
+## 0.9.0
 
+- Update egui to 0.36
 - Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
 
 ## 0.8.0

--- a/crates/egui_router/Cargo.toml
+++ b/crates/egui_router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_router"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 authors = ["Lucas Meurer"]
 description = "A SPA router for egui"

--- a/crates/egui_router/Cargo.toml
+++ b/crates/egui_router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_router"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2021"
 authors = ["Lucas Meurer"]
 description = "A SPA router for egui"

--- a/crates/egui_suspense/CHANGELOG.md
+++ b/crates/egui_suspense/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.1
+
+- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
+
 ## 0.12.0
 
 - Update egui to 0.35

--- a/crates/egui_suspense/CHANGELOG.md
+++ b/crates/egui_suspense/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 0.12.1
+## 0.13.0
 
+- Update egui to 0.36
 - Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
 
 ## 0.12.0

--- a/crates/egui_suspense/Cargo.toml
+++ b/crates/egui_suspense/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_suspense"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 authors = ["Lucas Meurer"]
 description = "Automatically show loading and error uis for egui"

--- a/crates/egui_suspense/Cargo.toml
+++ b/crates/egui_suspense/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_suspense"
-version = "0.12.1"
+version = "0.13.0"
 edition = "2021"
 authors = ["Lucas Meurer"]
 description = "Automatically show loading and error uis for egui"

--- a/crates/egui_thumbhash/CHANGELOG.md
+++ b/crates/egui_thumbhash/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 0.11.1
+## 0.12.0
 
+- Update egui to 0.36
 - Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
 
 ## 0.11.0

--- a/crates/egui_thumbhash/CHANGELOG.md
+++ b/crates/egui_thumbhash/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.11.1
+
+- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
+
 ## 0.11.0
 
 - Update egui to 0.35

--- a/crates/egui_thumbhash/Cargo.toml
+++ b/crates/egui_thumbhash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_thumbhash"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 authors = ["Lucas Meurer"]
 description = "Easily use thumbhashes in egui"

--- a/crates/egui_thumbhash/Cargo.toml
+++ b/crates/egui_thumbhash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_thumbhash"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2021"
 authors = ["Lucas Meurer"]
 description = "Easily use thumbhashes in egui"

--- a/crates/egui_virtual_list/CHANGELOG.md
+++ b/crates/egui_virtual_list/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.11.1
+
+- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
+- Update egui to 0.36 and MSRV to 1.95 ([#104](https://github.com/lucasmerlin/hello_egui/pull/104))
+
 ## 0.11.0
 
 - Update egui to 0.35

--- a/crates/egui_virtual_list/CHANGELOG.md
+++ b/crates/egui_virtual_list/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.11.1
+## 0.12.0
 
 - Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
 - Update egui to 0.36 and MSRV to 1.95 ([#104](https://github.com/lucasmerlin/hello_egui/pull/104))

--- a/crates/egui_virtual_list/Cargo.toml
+++ b/crates/egui_virtual_list/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_virtual_list"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2021"
 authors = ["Lucas Meurer"]
 homepage = "https://lucasmerlin.github.io/hello_egui/#/example/gallery"

--- a/crates/egui_virtual_list/Cargo.toml
+++ b/crates/egui_virtual_list/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_virtual_list"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 authors = ["Lucas Meurer"]
 homepage = "https://lucasmerlin.github.io/hello_egui/#/example/gallery"

--- a/crates/hello_egui_utils/CHANGELOG.md
+++ b/crates/hello_egui_utils/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.1
+
+- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
+
 ## 0.12.0
 
 - Update egui to 0.35

--- a/crates/hello_egui_utils/CHANGELOG.md
+++ b/crates/hello_egui_utils/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 0.12.1
+## 0.13.0
 
+- Update egui to 0.36
 - Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
 
 ## 0.12.0

--- a/crates/hello_egui_utils/Cargo.toml
+++ b/crates/hello_egui_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello_egui_utils"
-version = "0.12.1"
+version = "0.13.0"
 edition = "2021"
 description = "Utilities used by crates from https://github.com/lucasmerlin/hello_egui"
 license = "MIT"

--- a/crates/hello_egui_utils/Cargo.toml
+++ b/crates/hello_egui_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello_egui_utils"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 description = "Utilities used by crates from https://github.com/lucasmerlin/hello_egui"
 license = "MIT"

--- a/crates/hello_egui_utils_dev/CHANGELOG.md
+++ b/crates/hello_egui_utils_dev/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.1
+
+- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
+
 ## 0.4.0
 
 - Update egui to 0.35

--- a/crates/hello_egui_utils_dev/CHANGELOG.md
+++ b/crates/hello_egui_utils_dev/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 0.4.1
+## 0.5.0
 
+- Update egui to 0.36
 - Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
 
 ## 0.4.0

--- a/crates/hello_egui_utils_dev/Cargo.toml
+++ b/crates/hello_egui_utils_dev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello_egui_utils_dev"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 description = "Utilities used by crates from https://github.com/lucasmerlin/hello_egui"
 license = "MIT"

--- a/crates/hello_egui_utils_dev/Cargo.toml
+++ b/crates/hello_egui_utils_dev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello_egui_utils_dev"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 description = "Utilities used by crates from https://github.com/lucasmerlin/hello_egui"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `hello_egui_utils`: 0.12.0 -> 0.13.0 (✓ API compatible changes)
* `egui_animation`: 0.12.0 -> 0.13.0 (✓ API compatible changes)
* `egui_dnd`: 0.16.0 -> 0.17.0 (✓ API compatible changes)
* `egui_inbox`: 0.12.0 -> 0.13.0 (✓ API compatible changes)
* `egui_virtual_list`: 0.11.0 -> 0.12.0 (✓ API compatible changes)
* `egui_infinite_scroll`: 0.11.0 -> 0.12.0 (✓ API compatible changes)
* `hello_egui_utils_dev`: 0.4.0 -> 0.5.0 (✓ API compatible changes)
* `egui_flex`: 0.7.0 -> 0.8.0 (✓ API compatible changes)
* `egui_form`: 0.9.0 -> 0.10.0 (✓ API compatible changes)
* `egui_pull_to_refresh`: 0.12.0 -> 0.13.0 (✓ API compatible changes)
* `egui_suspense`: 0.12.0 -> 0.13.0 (✓ API compatible changes)
* `egui_router`: 0.8.0 -> 0.9.0 (✓ API compatible changes)
* `egui_thumbhash`: 0.11.0 -> 0.12.0 (✓ API compatible changes)
* `egui_material_icons`: 0.7.0 -> 0.8.0 (✓ API compatible changes)
* `hello_egui`: 0.12.0 -> 0.13.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `hello_egui_utils`

<blockquote>

## 0.13.0

- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
</blockquote>

## `egui_animation`

<blockquote>

## 0.13.0

- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
</blockquote>

## `egui_dnd`

<blockquote>

## 0.17.0

- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
- Add axis constraining to egui_dnd ([#103](https://github.com/lucasmerlin/hello_egui/pull/103))
</blockquote>

## `egui_inbox`

<blockquote>

## 0.13.0

- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
</blockquote>

## `egui_virtual_list`

<blockquote>

## 0.12.0

- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
- Update egui to 0.36 and MSRV to 1.95 ([#104](https://github.com/lucasmerlin/hello_egui/pull/104))
</blockquote>

## `egui_infinite_scroll`

<blockquote>

## 0.12.0

- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
</blockquote>

## `hello_egui_utils_dev`

<blockquote>

## 0.5.0

- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
</blockquote>

## `egui_flex`

<blockquote>

## 0.8.0

- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
</blockquote>

## `egui_form`

<blockquote>

## 0.10.0

- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
</blockquote>

## `egui_pull_to_refresh`

<blockquote>

## 0.13.0

- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
</blockquote>

## `egui_suspense`

<blockquote>

## 0.13.0

- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
</blockquote>

## `egui_router`

<blockquote>

## 0.9.0

- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
</blockquote>

## `egui_thumbhash`

<blockquote>

## 0.12.0

- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
</blockquote>

## `egui_material_icons`

<blockquote>

## 0.8.0

- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
</blockquote>

## `hello_egui`

<blockquote>

## 0.13.0

- Fix release-plz config for unpublished crates, update release PR description
- Add release-plz to automate releases ([#105](https://github.com/lucasmerlin/hello_egui/pull/105))
- Fix CI
- Update egui to 0.36 and MSRV to 1.95 ([#104](https://github.com/lucasmerlin/hello_egui/pull/104))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

> ⚠️ egui was updated: the versions were raised to the next minor by `scripts/bump_versions_on_egui_update.sh`.