### PR TITLE
Fix release failure due to publish order

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -51,6 +51,31 @@ branch.
 Install release-plz with `brew install release-plz` or
 `cargo binstall release-plz`.
 
+## Dev-dependencies between workspace crates
+
+Dev-dependencies on other crates of this workspace use a path without a
+version, e.g. `egui_inbox = { path = "../egui_inbox" }`. Cargo drops those from
+the published manifest, so the publish order does not have to account for them.
+
+With a version, `cargo publish` demands that the dev-dependency is already on
+crates.io, but release-plz ignores dev-dependencies when it sorts the crates for
+publishing ([release-plz#2697]) — the release then fails halfway through.
+
+[release-plz#2697]: https://github.com/release-plz/release-plz/issues/2697
+
+## Retrying a failed release
+
+`release_always = false` means the release job publishes only when the commit
+belongs to a PR whose branch name starts with `release-plz-`.
+
+- If the release failed for a reason outside the repo (crates.io, network),
+  re-run the failed job.
+- If the release needs a code fix, put the fix on a branch whose name starts
+  with `release-plz-` and merge that PR. The release job then publishes the
+  crates that are still missing from crates.io. Note that a merged release PR
+  cannot be reopened, and release-plz creates no new release PR while the
+  versions on `main` are already ahead of crates.io.
+
 ## New crates
 
 crates.io trusted publishing does not cover the first publish of a crate:

--- a/crates/egui_dnd/Cargo.toml
+++ b/crates/egui_dnd/Cargo.toml
@@ -20,9 +20,11 @@ simple-easing.workspace = true
 web-time = "1"
 
 [dev-dependencies]
-egui_infinite_scroll.workspace = true
-egui_virtual_list.workspace = true
-hello_egui_utils.workspace = true
+# Dev-deps on other workspace crates use a path without a version, so cargo
+# drops them from the published manifest and the publish order can ignore them.
+egui_infinite_scroll = { path = "../egui_infinite_scroll" }
+egui_virtual_list = { path = "../egui_virtual_list" }
+hello_egui_utils = { path = "../hello_egui_utils" }
 rand.workspace = true
 
 egui_extras.workspace = true

--- a/crates/egui_flex/Cargo.toml
+++ b/crates/egui_flex/Cargo.toml
@@ -16,8 +16,10 @@ egui.workspace = true
 [dev-dependencies]
 eframe = { workspace = true, default-features = true, features = ["wgpu"] }
 egui = { workspace = true, features = ["callstack"] }
-egui_inbox.workspace = true
-hello_egui_utils_dev = { workspace = true }
+# Dev-deps on other workspace crates use a path without a version, so cargo
+# drops them from the published manifest and the publish order can ignore them.
+egui_inbox = { path = "../egui_inbox" }
+hello_egui_utils_dev = { path = "../hello_egui_utils_dev" }
 
 egui_kittest = { workspace = true, features = ["wgpu", "snapshot"] }
 rstest = "0.26.1"

--- a/crates/egui_pull_to_refresh/Cargo.toml
+++ b/crates/egui_pull_to_refresh/Cargo.toml
@@ -13,7 +13,9 @@ egui.workspace = true
 
 [dev-dependencies]
 eframe = { workspace = true, default-features = true }
-egui_inbox.workspace = true
+# Dev-deps on other workspace crates use a path without a version, so cargo
+# drops them from the published manifest and the publish order can ignore them.
+egui_inbox = { path = "../egui_inbox" }
 ehttp.workspace = true
 
 [lints]

--- a/crates/egui_router/Cargo.toml
+++ b/crates/egui_router/Cargo.toml
@@ -41,11 +41,13 @@ js-sys = "0.3"
 wasm-bindgen = "0.2"
 
 [dev-dependencies]
-egui_inbox = { workspace = true, features = ["type_inbox"] }
 eframe = { workspace = true, default-features = true }
-egui_animation = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-egui_suspense = { workspace = true, features = ["async", "tokio"] }
+# Dev-deps on other workspace crates use a path without a version, so cargo
+# drops them from the published manifest and the publish order can ignore them.
+egui_inbox = { path = "../egui_inbox", features = ["type_inbox"] }
+egui_animation = { path = "../egui_animation" }
+egui_suspense = { path = "../egui_suspense", features = ["async", "tokio"] }
 
 [lints]
 workspace = true

--- a/crates/egui_virtual_list/Cargo.toml
+++ b/crates/egui_virtual_list/Cargo.toml
@@ -16,7 +16,9 @@ web-time = "1"
 [dev-dependencies]
 eframe = { workspace = true, default-features = true }
 rand.workspace = true
-hello_egui_utils_dev = { workspace = true }
+# Dev-deps on other workspace crates use a path without a version, so cargo
+# drops them from the published manifest and the publish order can ignore them.
+hello_egui_utils_dev = { path = "../hello_egui_utils_dev" }
 
 [lints]
 workspace = true


### PR DESCRIPTION
The release failed since release-plz doesn't check dev dependency when calculating the crate order. Changeing the dev dependencies to paths removes them from the published cargo.toml, working around the issue.